### PR TITLE
fix #6:  Add some styling that seperates the question and answer in the QnA section

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -468,7 +468,7 @@ section {
 .question {
   background-color: var(--color-bg);
   display: grid;
-  grid-template-columns: auto 1fr auto; /* Layout for text and arrow */
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   cursor: pointer;
   padding: 10px;
@@ -490,6 +490,7 @@ section {
 
 hr {
   margin: 10px 0;
+  opacity: 0.1;
 }
 
 /* Responsive: Single column layout for smaller screens */

--- a/css/index.css
+++ b/css/index.css
@@ -458,7 +458,7 @@ section {
   }
 }
 
-.qa-grid {}
+
 
 
 

--- a/css/index.css
+++ b/css/index.css
@@ -332,6 +332,7 @@ section {
   color: var(--color-text-secondary);
   display: flex;
   justify-self: center;
+  display: none;
 }
 
 /* Footer */
@@ -482,9 +483,7 @@ section {
   flex-direction: row-reverse;
 }
 
-.hidden {
-  display: none;
-}
+
 
 hr {
   margin: 10px 0;

--- a/css/index.css
+++ b/css/index.css
@@ -302,7 +302,7 @@ section {
 
 .qa-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(1, 1fr);
   gap: 2rem;
 }
 
@@ -447,3 +447,56 @@ section {
     margin-top: 2vh;
   }
 }
+
+.qa-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr); /* Two questions per row */
+  gap: 20px; /* Adjust spacing between cards */
+  justify-content: center;
+  align-items: start;
+}
+
+.qa-card {
+  background-color: var(--color-bg);
+  border-radius: 8px;
+  padding: 15px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  width:30vw;
+  justify-self: center;
+}
+
+.question {
+  background-color: var(--color-bg);
+  display: grid;
+  grid-template-columns: auto 1fr auto; /* Layout for text and arrow */
+  align-items: center;
+  cursor: pointer;
+  padding: 10px;
+  border-radius: 5px;
+}
+
+.question h3 {
+  margin-left: 10px;
+}
+
+.question span {
+  display: flex;
+  flex-direction: row-reverse;
+}
+
+.hidden {
+  display: none;
+}
+
+hr {
+  margin: 10px 0;
+}
+
+/* Responsive: Single column layout for smaller screens */
+@media (max-width: 768px) {
+  .qa-grid {
+    grid-template-columns: 1fr; /* 1 question per row on smaller screens */
+  }
+}
+
+

--- a/css/index.css
+++ b/css/index.css
@@ -302,25 +302,36 @@ section {
 
 .qa-grid {
   display: grid;
-  grid-template-columns: repeat(1, 1fr);
-  gap: 2rem;
+  grid-template-columns: repeat(2, 1fr);
+  /* Two questions per row */
+  gap: 20px;
+  /* Adjust spacing between cards */
+  justify-content: center;
+  align-items: stretch;
 }
 
 .qa-card {
-  background-color: rgba(17, 24, 39, 0.5);
-  padding: 1.5rem;
-  border-radius: 0.5rem;
-  border: 1px solid var(--color-border);
+  background-color: var(--color-bg);
+  border-radius: 8px;
+  padding: 15px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  max-width: 75vw;
+  justify-self: center;
+
+
 }
 
 .qa-card h3 {
   font-family: 'Orbitron', sans-serif;
   font-size: 1.25rem;
   margin-bottom: 0.75rem;
+  width: 37vw;
 }
 
 .qa-card p {
   color: var(--color-text-secondary);
+  display: flex;
+  justify-self: center;
 }
 
 /* Footer */
@@ -363,7 +374,6 @@ section {
 
 .github-button {
   margin-left: 1vw;
-
   background-color: var(--color-bg);
   border: solid 1px var(--color-accent);
   color: var(--color-accent);
@@ -448,22 +458,10 @@ section {
   }
 }
 
-.qa-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr); /* Two questions per row */
-  gap: 20px; /* Adjust spacing between cards */
-  justify-content: center;
-  align-items: start;
-}
+.qa-grid {}
 
-.qa-card {
-  background-color: var(--color-bg);
-  border-radius: 8px;
-  padding: 15px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-  width:30vw;
-  justify-self: center;
-}
+
+
 
 .question {
   background-color: var(--color-bg);
@@ -479,7 +477,7 @@ section {
   margin-left: 10px;
 }
 
-.question span {
+.question i {
   display: flex;
   flex-direction: row-reverse;
 }
@@ -496,8 +494,7 @@ hr {
 /* Responsive: Single column layout for smaller screens */
 @media (max-width: 768px) {
   .qa-grid {
-    grid-template-columns: 1fr; /* 1 question per row on smaller screens */
+    grid-template-columns: 1fr;
+    /* 1 question per row on smaller screens */
   }
 }
-
-

--- a/css/index.css
+++ b/css/index.css
@@ -325,7 +325,7 @@ section {
   font-family: 'Orbitron', sans-serif;
   font-size: 1.25rem;
   margin-bottom: 0.75rem;
-  width: 36vw;
+  width: 30vw;
 }
 
 .qa-card p {

--- a/css/index.css
+++ b/css/index.css
@@ -315,7 +315,7 @@ section {
   border-radius: 8px;
   padding: 15px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
-  max-width: 75vw;
+  max-width: 52vw;
   justify-self: center;
 
 
@@ -325,13 +325,14 @@ section {
   font-family: 'Orbitron', sans-serif;
   font-size: 1.25rem;
   margin-bottom: 0.75rem;
-  width: 37vw;
+  width: 36vw;
 }
 
 .qa-card p {
   color: var(--color-text-secondary);
   display: flex;
   justify-self: center;
+
   display: none;
 }
 
@@ -472,6 +473,8 @@ section {
   cursor: pointer;
   padding: 10px;
   border-radius: 5px;
+  max-width: 90%;
+
 }
 
 .question h3 {

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
     content="Programming, community, developers, coding, projects, learning, networking, open source">
   <meta name="author" content="Sourceware Lab">
   <link rel="icon" href="imgs/logo.png" type="image/x-icon">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=keyboard_arrow_down" />
+
   <!-- TODO: fill out meta tags when hosting the website online -->
   <!-- Facebook meta tags -->
   <!-- <meta property="og:url" content="summary">
@@ -168,34 +170,71 @@
       </div>
       <div class="qa-grid jetbrains-mono">
         <div class="qa-card">
-          <h3>Why should I join?</h3>
+            <div class="question">
+                <h3>Why should I join?</h3>
+                <span class="material-symbols-outlined">
+                    keyboard_arrow_down
+                </span>
+            </div>
+            <hr>
           <p>We learn together and grow by doing. You'll gain experience, knowledge and new friendships.
             Everyone is welcome, regardless of skill level. We're all here to learn and grow together.</p>
         </div>
         <div class="qa-card">
+          <div class="question">
+        <h3>Do I need to register somewhere to join and work on projects by others?</h3>
+        <span class="material-symbols-outlined">
+          keyboard_arrow_down
+      </span>
+  </div>
+  <hr>
+        <p>All you need is a discord and a github account to join.</p>
+      </div>
+        <div class="qa-card">
+            <div class="question">
           <h3>Can I share my own project and ask others to contribute on the server?</h3>
+          <span class="material-symbols-outlined">
+            keyboard_arrow_down
+        </span>
+    </div>
+    <hr>
           <p>You're welcome to share your project idea in the Project Hub on our Discord server!
             If the community shows interest and support, we can help you bring it to life by providing guidance,
             resources, and a space for collaboration</p>
         </div>
+     
         <div class="qa-card">
-          <h3>Do I need to register somewhere to join and work on projects by others?</h3>
-          <p>All you need is a discord and a github account to join.</p>
-        </div>
-        <div class="qa-card">
+            <div class="question">
           <h3>Will you promote my project? When will it appear on the website?</h3>
+          <span class="material-symbols-outlined">
+            keyboard_arrow_down
+        </span>
+    </div>
+    <hr>
           <p>If your project is shared in the Project Hub, gains community support, and reaches MVP status, it will be
             featured on the website.</p>
         </div>
         <div class="qa-card">
+            <div class="question">
           <h3>What are community projects on Sourceware Lab?</h3>
+          <span class="material-symbols-outlined">
+            keyboard_arrow_down
+        </span>
+    </div>
+    <hr>
           <p>Community projects on Sourceware Lab are our most actively developed initiatives. We provide them with the
             highest level of support and ensure a smooth,
             streamlined onboarding process so any member can easily join. These projects are also showcased on our
             website</p>
         </div>
         <div class="qa-card">
+            <div class="question">
           <h3>Do I need some kind of prior experience in programming to be able to join?</h3>
+          <span class="material-symbols-outlined">
+            keyboard_arrow_down
+        </span>
+    </div>
+    <hr>
           <p>We recommend that you already know the basics of at least one programming language,
             other than that no prior experience is needed, anyone can join, doesn't matter the experience,
             we're all here to learn and grow.</p>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,8 @@
     content="Programming, community, developers, coding, projects, learning, networking, open source">
   <meta name="author" content="Sourceware Lab">
   <link rel="icon" href="imgs/logo.png" type="image/x-icon">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=keyboard_arrow_down" />
+  <link rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=keyboard_arrow_down" />
 
   <!-- TODO: fill out meta tags when hosting the website online -->
   <!-- Facebook meta tags -->
@@ -170,71 +171,59 @@
       </div>
       <div class="qa-grid jetbrains-mono">
         <div class="qa-card">
-            <div class="question">
-                <h3>Why should I join?</h3>
-                <span class="material-symbols-outlined">
-                    keyboard_arrow_down
-                </span>
-            </div>
-            <hr>
+          <div class="question">
+            <h3>Why should I join?</h3>
+            <i data-lucide="chevron-down" class="icon"></i>
+          </div>
+          <hr>
           <p>We learn together and grow by doing. You'll gain experience, knowledge and new friendships.
             Everyone is welcome, regardless of skill level. We're all here to learn and grow together.</p>
         </div>
         <div class="qa-card">
           <div class="question">
-        <h3>Do I need to register somewhere to join and work on projects by others?</h3>
-        <span class="material-symbols-outlined">
-          keyboard_arrow_down
-      </span>
-  </div>
-  <hr>
-        <p>All you need is a discord and a github account to join.</p>
-      </div>
+            <h3>Do I need to register somewhere to join and work on projects by others?</h3>
+            <i data-lucide="chevron-down" class="icon"></i>
+          </div>
+          <hr>
+          <p>All you need is a discord and a github account to join.</p>
+        </div>
         <div class="qa-card">
-            <div class="question">
-          <h3>Can I share my own project and ask others to contribute on the server?</h3>
-          <span class="material-symbols-outlined">
-            keyboard_arrow_down
-        </span>
-    </div>
-    <hr>
+          <div class="question">
+            <h3>Can I share my own project and ask others to contribute on the server?</h3>
+            <i data-lucide="chevron-down" class="icon"></i>
+          </div>
+          <hr>
           <p>You're welcome to share your project idea in the Project Hub on our Discord server!
             If the community shows interest and support, we can help you bring it to life by providing guidance,
             resources, and a space for collaboration</p>
         </div>
-     
+
         <div class="qa-card">
-            <div class="question">
-          <h3>Will you promote my project? When will it appear on the website?</h3>
-          <span class="material-symbols-outlined">
-            keyboard_arrow_down
-        </span>
-    </div>
-    <hr>
+          <div class="question">
+            <h3>Will you promote my project? When will it appear on the website?</h3>
+            <i data-lucide="chevron-down" class="icon"></i>
+          </div>
+          <hr>
           <p>If your project is shared in the Project Hub, gains community support, and reaches MVP status, it will be
             featured on the website.</p>
         </div>
         <div class="qa-card">
-            <div class="question">
-          <h3>What are community projects on Sourceware Lab?</h3>
-          <span class="material-symbols-outlined">
-            keyboard_arrow_down
-        </span>
-    </div>
-    <hr>
+          <div class="question">
+            <h3>What are community projects on Sourceware Lab?</h3>
+            <i data-lucide="chevron-down" class="icon"></i>
+          </div>
+          <hr>
           <p>Community projects on Sourceware Lab are our most actively developed initiatives. We provide them with the
             highest level of support and ensure a smooth,
             streamlined onboarding process so any member can easily join. These projects are also showcased on our
             website</p>
         </div>
         <div class="qa-card">
-            <div class="question">
-          <h3>Do I need some kind of prior experience in programming to be able to join?</h3>
-          <span class="material-symbols-outlined">
-            keyboard_arrow_down
-        </span>
-    </div>
-    <hr>
+          <div class="question">
+            <h3>Do I need some kind of prior experience in programming to be able to join?</h3>
+            <i data-lucide="chevron-down" class="icon"></i>
+          </div>
+          <hr>
           <p>We recommend that you already know the basics of at least one programming language,
             other than that no prior experience is needed, anyone can join, doesn't matter the experience,
             we're all here to learn and grow.</p>

--- a/script.js
+++ b/script.js
@@ -25,18 +25,11 @@ document.querySelector(".logo-content").addEventListener("click", () => {
 
 // Check for element click to close the navigation bar
 document.querySelectorAll(".nav-links a").forEach(link => {
-    link.addEventListener("click", () => {
-        toggleMenu()
-    })
+  link.addEventListener("click", () => {
+    toggleMenu()
+  })
 })
 
-const paragraphs = document.querySelectorAll('.qa-card > p');
-paragraphs.forEach(paragraph => {
-    paragraph.style.display = 'flex';
-    paragraph.style.justifySelf = 'center';
-    paragraph.style.maxWidth = '70%';
-    
-});
 
 // Select all paragraphs inside .qa-card and initially hide them
 document.querySelectorAll('.qa-card p').forEach(para => {
@@ -48,18 +41,20 @@ const questions = document.querySelectorAll(".question");
 
 questions.forEach(question => {
   question.addEventListener("click", () => {
-      // Get the parent .qa-card of the clicked question
-      const parentCard = question.closest(".qa-card");
-      
-      // Find the <p> inside the same .qa-card
-      const paragraph = parentCard.querySelector("p");
+    // Get the parent .qa-card of the clicked question
+    const parentCard = question.closest(".qa-card");
 
-      // Toggle paragraph visibility
-      if (paragraph.style.display === "none") {
-          paragraph.style.display = "block";
+    // Find the <p> inside the same .qa-card
+    const paragraph = parentCard.querySelector("p");
 
-      } else {
-          paragraph.style.display = "none";
-      }
+    // Toggle paragraph visibility
+    if (paragraph.style.display === "none") {
+      paragraph.style.display = "block";
+
+    } else {
+      paragraph.style.display = "none";
+
+    }
   });
 });
+

--- a/script.js
+++ b/script.js
@@ -29,3 +29,33 @@ document.querySelectorAll(".nav-links a").forEach(link => {
         toggleMenu()
     })
 })
+
+const paragraphs = document.querySelectorAll('.qa-card > p');
+paragraphs.forEach(paragraph => {
+    paragraph.style.display = 'flex';
+    paragraph.style.justifySelf = 'center';
+    paragraph.style.maxWidth = '70%';
+    
+});
+
+// Select all the paragraph elements within sections and hide them
+const sectionParagraphs = document.querySelectorAll('.qa-card p');
+sectionParagraphs.forEach(para => {
+    para.style.display = "none";
+});
+
+const head = document.querySelectorAll(".question")
+head.forEach(header =>{
+    header.addEventListener("click",()=>{
+                
+        sectionParagraphs.forEach(para =>{
+            if (para.style.display ==="none") {
+                
+                para.style.display = "block";
+            }else{
+                
+                para.style.display = "none";
+            }
+        })
+    })
+})

--- a/script.js
+++ b/script.js
@@ -32,9 +32,6 @@ document.querySelectorAll(".nav-links a").forEach(link => {
 
 
 // Select all paragraphs inside .qa-card and initially hide them
-document.querySelectorAll('.qa-card p').forEach(para => {
-  para.style.display = "none";
-});
 
 // Select all question headers
 const questions = document.querySelectorAll(".question");

--- a/script.js
+++ b/script.js
@@ -38,24 +38,28 @@ paragraphs.forEach(paragraph => {
     
 });
 
-// Select all the paragraph elements within sections and hide them
-const sectionParagraphs = document.querySelectorAll('.qa-card p');
-sectionParagraphs.forEach(para => {
-    para.style.display = "none";
+// Select all paragraphs inside .qa-card and initially hide them
+document.querySelectorAll('.qa-card p').forEach(para => {
+  para.style.display = "none";
 });
 
-const head = document.querySelectorAll(".question")
-head.forEach(header =>{
-    header.addEventListener("click",()=>{
-                
-        sectionParagraphs.forEach(para =>{
-            if (para.style.display ==="none") {
-                
-                para.style.display = "block";
-            }else{
-                
-                para.style.display = "none";
-            }
-        })
-    })
-})
+// Select all question headers
+const questions = document.querySelectorAll(".question");
+
+questions.forEach(question => {
+  question.addEventListener("click", () => {
+      // Get the parent .qa-card of the clicked question
+      const parentCard = question.closest(".qa-card");
+      
+      // Find the <p> inside the same .qa-card
+      const paragraph = parentCard.querySelector("p");
+
+      // Toggle paragraph visibility
+      if (paragraph.style.display === "none") {
+          paragraph.style.display = "block";
+
+      } else {
+          paragraph.style.display = "none";
+      }
+  });
+});


### PR DESCRIPTION

This PR addresses issue #6 by improving the styling of the QnA section to clearly separate questions and answers. Additionally, it ensures that answers remain hidden until their respective questions are clicked.

Changes Implemented
✅ Added a border below each question for better separation.
✅ Added spacing (margin & padding) between questions and answers.
✅ Improved visibility by making the transition smooth when showing answers.
✅ Ensured only the clicked question's answer is displayed while keeping others hidden.